### PR TITLE
Clip horizontal overflow from full-bleed sections

### DIFF
--- a/design-system/elements/background/background.styles.tsx
+++ b/design-system/elements/background/background.styles.tsx
@@ -6,6 +6,11 @@ export const background = cva({
     minWidth: '100%',
     minHeight: '100svh',
     backgroundColor: 'gray.900',
+    // Full-bleed sections span 100vw, which is wider than the
+    // scrollbar-excluded content width; clip the resulting sub-pixel
+    // overflow so no horizontal scrollbar appears. `clip` (unlike
+    // `hidden`) keeps sticky/fixed positioning working.
+    overflowX: 'clip',
     transitionProperty: 'background-color',
     ...sharedTransitionProperties
   }

--- a/design-system/elements/background/background.styles.tsx
+++ b/design-system/elements/background/background.styles.tsx
@@ -9,7 +9,8 @@ export const background = cva({
     // Full-bleed sections span 100vw, which is wider than the
     // scrollbar-excluded content width; clip the resulting sub-pixel
     // overflow so no horizontal scrollbar appears. `clip` (unlike
-    // `hidden`) keeps sticky/fixed positioning working.
+    // `hidden`) does not create a scroll container, so `position: sticky`
+    // descendants (e.g. the top bar) keep working.
     overflowX: 'clip',
     transitionProperty: 'background-color',
     ...sharedTransitionProperties


### PR DESCRIPTION
Clip the sub-pixel overflow on the Background wrapper.